### PR TITLE
Refactor springAutoCompile scripts to run Spring Boot application in an endless loop to prevent the spring app from stopping

### DIFF
--- a/services/account-service/springAutoCompile.sh
+++ b/services/account-service/springAutoCompile.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# Start Spring Boot application in the background
-mvn spring-boot:run -Dspring-boot.run.fork=false &
+# Run Spring Boot application in an endless loop in the background
+while true; do
+  mvn spring-boot:run -Dspring-boot.run.fork=false &
+  wait $!
+done &
 
 # Watch for changes in the src directory and trigger mvn compile
 find /app/src | entr -n -r mvn -T 1C compile

--- a/services/document-service/springAutoCompile.sh
+++ b/services/document-service/springAutoCompile.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# Start Spring Boot application in the background
-mvn spring-boot:run -Dspring-boot.run.fork=false &
+# Run Spring Boot application in an endless loop in the background
+while true; do
+  mvn spring-boot:run -Dspring-boot.run.fork=false &
+  wait $!
+done &
 
 # Watch for changes in the src directory and trigger mvn compile
 find /app/src | entr -n -r mvn -T 1C compile


### PR DESCRIPTION
This pull request includes changes to the `springAutoCompile.sh` scripts for both the account and document services. The modifications ensure that the Spring Boot applications run in an endless loop in the background.

Changes to `springAutoCompile.sh` scripts:

* [`services/account-service/springAutoCompile.sh`](diffhunk://#diff-d487e91e15facbb830f44151c713156328943198369b8f7ade012795eb32088dL3-R7): Updated the script to run the Spring Boot application in an endless loop in the background.
* [`services/document-service/springAutoCompile.sh`](diffhunk://#diff-d487e91e15facbb830f44151c713156328943198369b8f7ade012795eb32088dL3-R7): Updated the script to run the Spring Boot application in an endless loop in the background.