### PR TITLE
Enhance Dockerfiles and scripts: install dos2unix for script compatibility and update autocompile logic for improved functionality

### DIFF
--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -16,19 +16,20 @@ ENV SPRING_PROFILES_ACTIVE=dev
 
 WORKDIR /app
 
-# Install entr (file-watcher) in a single layer
-RUN apt-get update && apt-get install -y entr
+# Install entr (file-watcher) and dos2unix in a single layer
+RUN apt-get update && apt-get install -y entr dos2unix && rm -rf /var/lib/apt/lists/*
 
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 
-COPY springAutoCompile.sh .
-RUN chmod +x springAutoCompile.sh
-
 COPY . .
 
+# Convert the autocompile script to Unix format and make it executable
+RUN dos2unix springAutoCompile.sh
+RUN chmod +x springAutoCompile.sh
+
 EXPOSE 8080
-CMD ["sh", "./springAutoCompile.sh"]
+ENTRYPOINT ["./springAutoCompile.sh"]
 
 # Production Stage
 FROM gcr.io/distroless/java21:nonroot

--- a/services/account-service/springAutoCompile.sh
+++ b/services/account-service/springAutoCompile.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-# Run Spring Boot application in an endless loop in the background
-while true; do
-  mvn spring-boot:run -Dspring-boot.run.fork=false &
-  wait $!
-done &
-
-# Watch for changes in the src directory and trigger mvn compile
-find /app/src | entr -n -r mvn -T 1C compile
+# Run Spring Boot application in an endless loop and watch for changes in the src directory
+while true
+do
+  find /app/src | entr -n -r -d mvn spring-boot:run -Dspring-boot.run.fork=false
+done

--- a/services/document-service/Dockerfile
+++ b/services/document-service/Dockerfile
@@ -16,19 +16,20 @@ ENV SPRING_PROFILES_ACTIVE=dev
 
 WORKDIR /app
 
-# Install entr (file-watcher) in a single layer
-RUN apt-get update && apt-get install -y entr
+# Install entr (file-watcher) and dos2unix in a single layer
+RUN apt-get update && apt-get install -y entr dos2unix && rm -rf /var/lib/apt/lists/*
 
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 
-COPY springAutoCompile.sh .
-RUN chmod +x springAutoCompile.sh
-
 COPY . .
 
+# Convert the autocompile script to Unix format and make it executable
+RUN dos2unix springAutoCompile.sh
+RUN chmod +x springAutoCompile.sh
+
 EXPOSE 8080
-CMD ["sh", "./springAutoCompile.sh"]
+ENTRYPOINT ["./springAutoCompile.sh"]
 
 # Production Stage
 FROM gcr.io/distroless/java21:nonroot

--- a/services/document-service/springAutoCompile.sh
+++ b/services/document-service/springAutoCompile.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-# Run Spring Boot application in an endless loop in the background
-while true; do
-  mvn spring-boot:run -Dspring-boot.run.fork=false &
-  wait $!
-done &
-
-# Watch for changes in the src directory and trigger mvn compile
-find /app/src | entr -n -r mvn -T 1C compile
+# Run Spring Boot application in an endless loop and watch for changes in the src directory
+while true
+do
+  find /app/src | entr -n -r -d mvn spring-boot:run -Dspring-boot.run.fork=false
+done


### PR DESCRIPTION
This pull request includes updates to the Dockerfiles and the `springAutoCompile.sh` scripts for both the `account-service` and `document-service`. The changes improve the setup process and streamline the script execution.

### Dockerfile improvements:

* Added `dos2unix` installation to convert scripts to Unix format and removed unnecessary apt-get lists to reduce image size.
* Changed the command to use `ENTRYPOINT` instead of `CMD` for better process handling.

### Script updates:

* Simplified the `springAutoCompile.sh` script to run the Spring Boot application in an endless loop and watch for changes in the `src` directory using `entr`.