### PR TITLE
Refactor CORS configuration: remove protocol from allowed origins in SecurityConfig

### DIFF
--- a/services/account-service/src/main/kotlin/md/edit/services/account/configuration/SecurityConfig.kt
+++ b/services/account-service/src/main/kotlin/md/edit/services/account/configuration/SecurityConfig.kt
@@ -36,11 +36,14 @@ class SecurityConfig(
         // Disable the default CSRF protection
         http.csrf { it.disable() }
 
+        // Remove the protocol from the host
+        val host = applicationHost.replace("https://", "").replace("http://", "")
+
         // Enable CORS and allow requests from the frontend
         http.cors {
             val source = UrlBasedCorsConfigurationSource()
             val config = CorsConfiguration()
-            config.allowedOrigins = listOf(applicationHost)
+            config.allowedOrigins = listOf("https://$host", "http://$host")
             config.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
             config.allowedHeaders = listOf("*")
             config.allowCredentials = true

--- a/services/document-service/src/main/kotlin/md/edit/services/document/configuration/SecurityConfig.kt
+++ b/services/document-service/src/main/kotlin/md/edit/services/document/configuration/SecurityConfig.kt
@@ -40,11 +40,14 @@ class SecurityConfig(
         // Disable the default CSRF protection
         http.csrf { it.disable() }
 
+        // Remove the protocol from the host
+        val host = applicationHost.replace("https://", "").replace("http://", "")
+
         // Enable CORS and allow requests from the frontend
         http.cors {
             val source = UrlBasedCorsConfigurationSource()
             val config = CorsConfiguration()
-            config.allowedOrigins = listOf(applicationHost)
+            config.allowedOrigins = listOf("https://$host", "http://$host")
             config.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
             config.allowedHeaders = listOf("*")
             config.allowCredentials = true


### PR DESCRIPTION
This pull request includes changes to the `SecurityConfig` class in both the `account-service` and `document-service` to improve the handling of CORS configuration by normalizing the host URL. The changes ensure that the protocol is removed from the host before setting the allowed origins, which helps in preventing potential mismatches.

Improvements to CORS configuration:

* [`services/account-service/src/main/kotlin/md/edit/services/account/configuration/SecurityConfig.kt`](diffhunk://#diff-60bd994b5f0f32761d7897aa570d8013e26619c161a375b0f71814f4b536770aR39-R46): Added code to remove the protocol from `applicationHost` and updated `config.allowedOrigins` to include both `https` and `http` versions of the host.
* [`services/document-service/src/main/kotlin/md/edit/services/document/configuration/SecurityConfig.kt`](diffhunk://#diff-9358e833829fb8b4d72b0c426f2ee67e47102ba62dfaef3e27e73e534d77cb84R43-R50): Added code to remove the protocol from `applicationHost` and updated `config.allowedOrigins` to include both `https` and `http` versions of the host.