### PR TITLE
Setup GitHub CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,13 +1,62 @@
-name: Publish Docker Images
+name: Build and Publish Docker Images
 
 on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  build-and-publish:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Get commit hash
+      id: commit
+      run: |
+        COMMIT_HASH=$(git rev-parse --short HEAD)
+        echo "COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
+        echo "::set-output name=commit_hash::${COMMIT_HASH}"
+
+    - name: Build account-service image
+      working-directory: ./services/account-service
+      run: |
+        docker build -t ghcr.io/${{ github.repository_owner }}/account-service:latest -t ghcr.io/${{ github.repository_owner }}/account-service:${{ steps.commit.outputs.commit_hash }} .
+
+    - name: Build document-service image
+      working-directory: ./services/document-service
+      run: |
+        docker build -t ghcr.io/${{ github.repository_owner }}/document-service:latest -t ghcr.io/${{ github.repository_owner }}/document-service:${{ steps.commit.outputs.commit_hash }} .
+
+    - name: Build file-service image
+      working-directory: ./services/file-service
+      run: |
+        docker build -t ghcr.io/${{ github.repository_owner }}/file-service:latest -t ghcr.io/${{ github.repository_owner }}/file-service:${{ steps.commit.outputs.commit_hash }} .
+
+    - name: Build frontend image
+      working-directory: ./services/frontend
+      run: |
+        docker build -t ghcr.io/${{ github.repository_owner }}/frontend:latest -t ghcr.io/${{ github.repository_owner }}/frontend:${{ steps.commit.outputs.commit_hash }} .
+
+    outputs:
+      commit_hash: ${{ steps.commit.outputs.commit_hash }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push'
     permissions:
       contents: read
       packages: write
@@ -27,34 +76,22 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get commit hash
-      id: commit
-      run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-    - name: Build and push account-service image
-      working-directory: ./services/account-service
+    - name: Publish account-service image
       run: |
-        docker build -t ghcr.io/${{ github.repository_owner }}/account-service:latest -t ghcr.io/${{ github.repository_owner }}/account-service:${{ env.COMMIT_HASH }} .
         docker push ghcr.io/${{ github.repository_owner }}/account-service:latest
-        docker push ghcr.io/${{ github.repository_owner }}/account-service:${{ env.COMMIT_HASH }}
+        docker push ghcr.io/${{ github.repository_owner }}/account-service:${{ needs.build.outputs.commit_hash }}
 
-    - name: Build and push document-service image
-      working-directory: ./services/document-service
+    - name: Publish document-service image
       run: |
-        docker build -t ghcr.io/${{ github.repository_owner }}/document-service:latest -t ghcr.io/${{ github.repository_owner }}/document-service:${{ env.COMMIT_HASH }} .
         docker push ghcr.io/${{ github.repository_owner }}/document-service:latest
-        docker push ghcr.io/${{ github.repository_owner }}/document-service:${{ env.COMMIT_HASH }}
+        docker push ghcr.io/${{ github.repository_owner }}/document-service:${{ needs.build.outputs.commit_hash }}
 
-    - name: Build and push file-service image
-      working-directory: ./services/file-service
+    - name: Publish file-service image
       run: |
-        docker build -t ghcr.io/${{ github.repository_owner }}/file-service:latest -t ghcr.io/${{ github.repository_owner }}/file-service:${{ env.COMMIT_HASH }} .
         docker push ghcr.io/${{ github.repository_owner }}/file-service:latest
-        docker push ghcr.io/${{ github.repository_owner }}/file-service:${{ env.COMMIT_HASH }}
+        docker push ghcr.io/${{ github.repository_owner }}/file-service:${{ needs.build.outputs.commit_hash }}
 
-    - name: Build and push frontend image
-      working-directory: ./services/frontend
+    - name: Publish frontend image
       run: |
-        docker build -t ghcr.io/${{ github.repository_owner }}/frontend:latest -t ghcr.io/${{ github.repository_owner }}/frontend:${{ env.COMMIT_HASH }} .
         docker push ghcr.io/${{ github.repository_owner }}/frontend:latest
-        docker push ghcr.io/${{ github.repository_owner }}/frontend:${{ env.COMMIT_HASH }}
+        docker push ghcr.io/${{ github.repository_owner }}/frontend:${{ needs.build.outputs.commit_hash }}


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for building and publishing Docker images for multiple services. The workflow is triggered on pushes and pull requests to the `main` branch. It consists of two jobs: `build` and `publish`.

### Workflow setup:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cR1-R97): Added a new workflow to build and publish Docker images for `account-service`, `document-service`, `file-service`, and `frontend`. The workflow includes steps for checking out the repository, setting up Docker Buildx, building images, and publishing them to GitHub Container Registry.