### PR TITLE
Add dev-nginx to the github ci/cd for use in local kubernetes

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -66,3 +66,12 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/frontend:latest
             ghcr.io/${{ github.repository }}/frontend:${{ env.COMMIT_HASH }}
+
+      - name: Build and push dev-nginx
+        uses: docker/build-push-action@v6
+        with:
+          context: ./dev/nginx
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/dev-nginx:latest
+            ghcr.io/${{ github.repository }}/dev-nginx:${{ env.COMMIT_HASH }}


### PR DESCRIPTION
This pull request includes an addition to the `.github/workflows/build-and-publish.yml` file to build and push a new Docker image for `dev-nginx`.

* Added a new job to build and push the `dev-nginx` Docker image using `docker/build-push-action@v6` with the context set to `./dev/nginx`. The image will be tagged with `latest` and `${{ env.COMMIT_HASH }}`.