### PR TITLE
Move hostnames to env, add EDITMD_SESSION_COOKIE_SECURE

### DIFF
--- a/services/account-service/src/main/resources/application.properties
+++ b/services/account-service/src/main/resources/application.properties
@@ -25,7 +25,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # Session Cookie Configuration
 server.servlet.session.cookie.name=${edit-md.session.cookie.name}
 server.servlet.session.cookie.same-site=lax
-server.servlet.session.cookie.secure=true
+server.servlet.session.cookie.secure=${EDITMD_SESSION_COOKIE_SECURE:true}
 server.servlet.session.cookie.path=/
 server.servlet.session.timeout=30m
 

--- a/services/frontend/src/routes/+layout.server.ts
+++ b/services/frontend/src/routes/+layout.server.ts
@@ -1,12 +1,15 @@
 import { fetchProxy, SessionError } from '$lib/fetchLib';
 import type { LayoutServerLoad } from './$types';
+import {env} from "$env/dynamic/private";
 
 export const load: LayoutServerLoad = async (req) => {
 	try {
 		const controller = new AbortController();
 		const timeoutId = setTimeout(() => controller.abort(), 500);
 
-		let resp = await fetchProxy(req, 'http://account-service:8080/api/accounts/me', {
+		const host = env.EDITMD_ACCOUNT_SERVICE_HOST;
+
+		let resp = await fetchProxy(req, host + '/api/accounts/me', {
 			signal: controller.signal
 		});
 

--- a/services/frontend/src/routes/+page.server.ts
+++ b/services/frontend/src/routes/+page.server.ts
@@ -1,6 +1,7 @@
 import { fetchProxy, SessionError } from '$lib/fetchLib';
 import type { ServerLoadEvent } from '@sveltejs/kit';
 import type { LayoutRouteId, PageServerLoad, RouteParams } from './$types';
+import {env} from "$env/dynamic/private";
 
 export const load: PageServerLoad = async (req) => {
 	let data = {
@@ -10,10 +11,12 @@ export const load: PageServerLoad = async (req) => {
 		}
 	};
 
+	const documentServiceHost = env.EDITMD_DOCUMENT_SERVICE_HOST;
+
 	try {
 		const [owned, shared] = await Promise.all([
-			fetchData(req, 'http://document-service:8080/api/documents/owned'),
-			fetchData(req, 'http://document-service:8080/api/documents/shared')
+			fetchData(req, documentServiceHost + '/api/documents/owned'),
+			fetchData(req, documentServiceHost + '/api/documents/shared')
 		]);
 
 		data.documents.owned = owned;

--- a/services/frontend/src/routes/[docId]/+page.server.ts
+++ b/services/frontend/src/routes/[docId]/+page.server.ts
@@ -1,10 +1,13 @@
 import { fetchProxy, SessionError } from '$lib/fetchLib';
 import type { PageServerLoad } from './$types';
+import {env} from "$env/dynamic/private";
 
 export const load: PageServerLoad = async (req) => {
 	let data = {
 		document: undefined
 	};
+
+	const documentServiceHost = env.EDITMD_DOCUMENT_SERVICE_HOST;
 
 	try {
 		const controller = new AbortController();
@@ -12,7 +15,7 @@ export const load: PageServerLoad = async (req) => {
 
 		let resp = await fetchProxy(
 			req,
-			`http://document-service:8080/api/documents/${req.params.docId}`,
+			`${documentServiceHost}/api/documents/${req.params.docId}`,
 			{
 				signal: controller.signal
 			}

--- a/services/frontend/src/routes/[docId]/view/+page.server.ts
+++ b/services/frontend/src/routes/[docId]/view/+page.server.ts
@@ -1,10 +1,13 @@
 import { fetchProxy, SessionError } from '$lib/fetchLib';
 import type { PageServerLoad } from './$types';
+import {env} from "$env/dynamic/private";
 
 export const load: PageServerLoad = async (req) => {
 	let data = {
 		document: undefined
 	};
+
+	const documentServiceHost = env.EDITMD_DOCUMENT_SERVICE_HOST;
 
 	try {
 		const controller = new AbortController();
@@ -12,7 +15,7 @@ export const load: PageServerLoad = async (req) => {
 
 		let resp = await fetchProxy(
 			req,
-			`http://document-service:8080/api/documents/${req.params.docId}`,
+			`${documentServiceHost}/api/documents/${req.params.docId}`,
 			{
 				signal: controller.signal
 			}


### PR DESCRIPTION
This pull request includes changes to improve the configuration of environment variables and enhance the security settings. The most important changes involve updating the session cookie configuration and modifying the service host URLs to use environment variables.

Configuration and security improvements:

* [`services/account-service/src/main/resources/application.properties`](diffhunk://#diff-a1149e4a23e041c0a2c0b5cde8afb690df1f0a5e6bfaa823bf699737effca709L28-R28): Updated the `server.servlet.session.cookie.secure` property to use an environment variable for better flexibility and security.

Service host URL updates:

* [`services/frontend/src/routes/+layout.server.ts`](diffhunk://#diff-fd2163a30fc709cab8523c96d98650e5ced761402e9514ba1a88709980e0d749R3-R12): Introduced the `env` import to dynamically use the `EDITMD_ACCOUNT_SERVICE_HOST` environment variable for the account service host URL.
* [`services/frontend/src/routes/+page.server.ts`](diffhunk://#diff-bda88573bdde1f9a7030e40e81037e0b703e11471668b093e72db67952c5b0f6R4): Added the `env` import and updated the document service host URLs to use the `EDITMD_DOCUMENT_SERVICE_HOST` environment variable. [[1]](diffhunk://#diff-bda88573bdde1f9a7030e40e81037e0b703e11471668b093e72db67952c5b0f6R4) [[2]](diffhunk://#diff-bda88573bdde1f9a7030e40e81037e0b703e11471668b093e72db67952c5b0f6R14-R19)
* `services/frontend/src/routes/[docId]/+page.server.ts`: Included the `env` import and changed the document service host URL to use the `EDITMD_DOCUMENT_SERVICE_HOST` environment variable. ([services/frontend/src/routes/[docId]/+page.server.tsR3-R18](diffhunk://#diff-848e6f06f86fa304f3b1bd861ce10ffdcc4583d9581d5319b16798f706e0c5a9R3-R18))
* `services/frontend/src/routes/[docId]/view/+page.server.ts`: Added the `env` import and modified the document service host URL to leverage the `EDITMD_DOCUMENT_SERVICE_HOST` environment variable. ([services/frontend/src/routes/[docId]/+page.server.tsR3-R18](diffhunk://#diff-848e6f06f86fa304f3b1bd861ce10ffdcc4583d9581d5319b16798f706e0c5a9R3-R18))