### PR TITLE
Fix dompurify causing a 500 error

### DIFF
--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -27,7 +27,6 @@
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.46.1",
 		"globals": "^15.14.0",
-		"isomorphic-dompurify": "^2.19.0",
 		"marked": "^15.0.4",
 		"node-emoji": "^2.2.0",
 		"prettier": "^3.4.2",
@@ -39,6 +38,9 @@
 		"typescript": "^5.7.2",
 		"typescript-eslint": "^8.19.0",
 		"vite": "^5.4.11"
+	},
+	"dependencies": {
+		"isomorphic-dompurify": "^2.19.0"
 	},
 	"pnpm": {
 		"overrides": {

--- a/services/frontend/pnpm-lock.yaml
+++ b/services/frontend/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      isomorphic-dompurify:
+        specifier: ^2.19.0
+        version: 2.19.0
     devDependencies:
       '@codemirror/commands':
         specifier: ^6.7.1
@@ -53,9 +57,6 @@ importers:
       globals:
         specifier: ^15.14.0
         version: 15.14.0
-      isomorphic-dompurify:
-        specifier: ^2.19.0
-        version: 2.19.0
       marked:
         specifier: ^15.0.4
         version: 15.0.4


### PR DESCRIPTION
This pull request includes changes to the `services/frontend` package configuration files to adjust the dependencies and devDependencies for `isomorphic-dompurify`.

Dependency adjustments:

* [`services/frontend/package.json`](diffhunk://#diff-0d005dbd9d9f66983f95fa01fa375184cf69dac9ae841050c11f07ebcc6789fdL30): Moved `isomorphic-dompurify` from `devDependencies` to `dependencies`. [[1]](diffhunk://#diff-0d005dbd9d9f66983f95fa01fa375184cf69dac9ae841050c11f07ebcc6789fdL30) [[2]](diffhunk://#diff-0d005dbd9d9f66983f95fa01fa375184cf69dac9ae841050c11f07ebcc6789fdR42-R44)

* [`services/frontend/pnpm-lock.yaml`](diffhunk://#diff-35d07c121411dc8af8a55f4bad862b16e0bc926075487fb659c170d9f60af7bcR13-R16): Updated the `dependencies` section to include `isomorphic-dompurify` and removed it from the `devDependencies` section. [[1]](diffhunk://#diff-35d07c121411dc8af8a55f4bad862b16e0bc926075487fb659c170d9f60af7bcR13-R16) [[2]](diffhunk://#diff-35d07c121411dc8af8a55f4bad862b16e0bc926075487fb659c170d9f60af7bcL56-L58)