### PR TITLE
New endpoint for directly displaying/downloading image files

### DIFF
--- a/services/file-service/src/main/kotlin/md/edit/services/file/controllers/FileController.kt
+++ b/services/file-service/src/main/kotlin/md/edit/services/file/controllers/FileController.kt
@@ -2,14 +2,14 @@ package md.edit.services.file.controllers
 
 import md.edit.services.file.dtos.FileDtoOut
 import md.edit.services.file.services.FileService
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
 import java.util.*
 
 
@@ -26,6 +26,17 @@ class FileController(private val fileService: FileService) {
     fun getPresignedDownloadUrl(@PathVariable fileId: UUID, authentication: Authentication): ResponseEntity<String> {
         val presignedUrl = fileService.generatePresignedDownloadUrl(fileId, authentication)
         return ResponseEntity.ok(presignedUrl)
+    }
+
+    @GetMapping("image/{fileId}/download")
+    fun downloadImage(@PathVariable fileId: UUID, authentication: Authentication): ResponseEntity<InputStreamResource> {
+        val file = fileService.getFileInformation(fileId, authentication)
+        val fileName = file.path.substring(file.path.lastIndexOf('/') + 1)
+        val resource = fileService.getInputStreamOfImage(fileId, authentication)
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"${fileName}\"")
+            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .body(resource)
     }
 
     @GetMapping("/")

--- a/services/file-service/src/main/kotlin/md/edit/services/file/exceptions/NotAnImageException.kt
+++ b/services/file-service/src/main/kotlin/md/edit/services/file/exceptions/NotAnImageException.kt
@@ -1,0 +1,9 @@
+package md.edit.services.file.exceptions
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Requested file ist not an image")
+class NotAnImageException: RuntimeException() {
+    override var message: String = "Requested file ist not an image"
+}

--- a/services/file-service/src/main/kotlin/md/edit/services/file/repos/FileRepository.kt
+++ b/services/file-service/src/main/kotlin/md/edit/services/file/repos/FileRepository.kt
@@ -7,6 +7,7 @@ import md.edit.services.file.exceptions.MinIOException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
 import java.io.IOException
+import java.io.InputStream
 import java.util.concurrent.TimeUnit
 
 @Repository
@@ -42,6 +43,21 @@ class FileRepository(private val minioClient: MinioClient) {
                     .build()
             )
         } catch (e: MinioException) {
+            throw MinIOException()
+        }
+    }
+
+    fun getInputStreamOfImage(filePath: String): InputStream {
+        try{
+            val stream = minioClient.getObject(
+                GetObjectArgs.builder()
+                    .bucket(bucketName)
+                    .`object`(filePath)
+                    .build()
+            )
+
+            return stream
+        } catch(e: MinioException) {
             throw MinIOException()
         }
     }


### PR DESCRIPTION
Via the endpoint `https://127.0.0.1/api/files/image/{fileId}/download` image files can be displayed directly in the Browser without the need of presigned URLs. The user can then, if they want, download the image to their local machine.